### PR TITLE
Access-Control-Expose-Headers added to response headers

### DIFF
--- a/src/main/scala/de/frosner/pia/Main.scala
+++ b/src/main/scala/de/frosner/pia/Main.scala
@@ -45,7 +45,10 @@ object Main extends App {
   val port = 8080
 
   private val predictionsEndpoint = "predictions"
-  val route = respondWithHeader(RawHeader("Access-Control-Allow-Origin", "*")) {
+  val route = respondWithHeaders(
+    RawHeader("Access-Control-Allow-Origin", "*"),
+    RawHeader("Access-Control-Expose-Headers", "location")
+  ) {
     path(predictionsEndpoint) {
       get {
         complete {


### PR DESCRIPTION
This is necessary for the clients which support CORS to be able to access "location" header.
